### PR TITLE
Adds a Research Lathe to the Ghost Cafe - Take Two!

### DIFF
--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -17312,6 +17312,7 @@
 	pixel_y = 10
 	},
 /obj/item/nanite_remote,
+/obj/item/nanite_remote/comm,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -22756,13 +22757,8 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "xBF" = (
-/obj/structure/table,
-/obj/item/storage/box/disks_nanite{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/item/nanite_remote/comm,
 /obj/machinery/light,
+/obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},


### PR DESCRIPTION
Adds a Research Protolathe to the ghost cafe's nanite lab.

## About The Pull Request

Replaces one of the tables in the Ghost Cafe's Nanite Lab with a research protolathe (which replaced a box of nanite data disks, as these can be printed in the lathe.

This is my first PR via Github, I really hope I did this right.

## Why It's Good For The Game

This adds more ways for ghosts to spend their time and to use the cafe for experimentation. Isn't it weird to have the Cargo, Service and Sec lathes and no others?

## Changelog
:cl:
add: Research Protolathe in the Ghost Cafe Nanite Lab
del: A table with a box of Nanite Data Disks
tweak: Moved a nanite injector one tile to the west.

/:cl:
